### PR TITLE
fix: prevent calling .setup() twice

### DIFF
--- a/plugin/guttermarks.lua
+++ b/plugin/guttermarks.lua
@@ -3,7 +3,9 @@ if vim.g.loaded_guttermarks == 1 then
 end
 vim.g.loaded_guttermarks = 1
 
-require("guttermarks").setup()
+if not require("guttermarks").is_enabled then
+  require("guttermarks").setup()
+end
 
 local function guttermarks_command(opts)
   local subcommand = opts.fargs[1]


### PR DESCRIPTION
`setup()` was called unconditionally, and `setup()` with no arguments uses the default config. This meant that if the user's `init.lua` ran before `plugin/guttermarks.lua`, their config would be reset.

I'm new to nvim so I'm not sure if this is the "proper" convention to do this, but this fixed the issue for me so I figured I'd send a patch. Feel free to close if this isn't right!

For the record, I installed the plugin by simply `git clone`-ing the repo into [a pack/*/start/](https://neovim.io/doc/user/pack/) dir, no package manager, and all of my config lives in my  `init.lua`. This might be why I had the issue?


Anyhow, thanks for this plugin! I was in the exact case you mentioned in the README.