### PR TITLE
chore: replace deprecated vim.validate({}) form

### DIFF
--- a/lua/guttermarks/validation.lua
+++ b/lua/guttermarks/validation.lua
@@ -14,103 +14,84 @@ local function is_non_empty_string(value)
   return type(value) == "string" and value ~= ""
 end
 
+-- Validate arguments using a compatibility wrapper for vim.validate.
+-- Falls back to the legacy signature on older Neovim versions.
+local validate
+if vim.fn.has("nvim-0.11") == 1 then
+  validate = function(name, value, validator, optional, message)
+    return vim.validate(name, value, validator, optional, message)
+  end
+else
+  validate = function(name, value, validator, optional, message)
+    return vim.validate({ [name] = { value, validator, optional, message } })
+  end
+end
+
 --- Validates a mark configuration (local_mark, global_mark, or special_mark)
 ---@param mark_config table
 ---@param mark_type string
 local function validate_mark_config(mark_config, mark_type)
   if mark_config.enabled ~= nil then
-    vim.validate({
-      [mark_type .. ".enabled"] = { mark_config.enabled, "boolean" },
-    })
+    validate(mark_type .. ".enabled", mark_config.enabled, "boolean")
   end
 
   if mark_config.sign ~= nil then
-    vim.validate({
-      [mark_type .. ".sign"] = {
-        mark_config.sign,
-        function(v)
-          if type(v) == "string" then
-            return is_non_empty_string(v)
-          elseif type(v) == "function" then
-            return true
-          end
-          return false
-        end,
-        "string or function (non-empty)",
-      },
-    })
+    validate(mark_type .. ".sign", mark_config.sign, function(v)
+      if type(v) == "string" then
+        return is_non_empty_string(v)
+      elseif type(v) == "function" then
+        return true
+      end
+      return false
+    end, "string or function (non-empty)")
   end
 
   if mark_config.highlight_group ~= nil then
-    vim.validate({
-      [mark_type .. ".highlight_group"] = { mark_config.highlight_group, "string" },
-    })
+    validate(mark_type .. ".highlight_group", mark_config.highlight_group, "string")
   end
 
   if mark_config.priority ~= nil then
-    vim.validate({
-      [mark_type .. ".priority"] = {
-        mark_config.priority,
-        is_positive_integer,
-        "positive integer",
-      },
-    })
+    validate(mark_type .. ".priority", mark_config.priority, is_positive_integer, "positive integer")
   end
 
   if mark_type == "special_mark" and mark_config.marks ~= nil then
-    vim.validate({
-      ["special_mark.marks"] = { mark_config.marks, "table" },
-    })
+    validate("special_mark.marks", mark_config.marks, "table")
   end
 end
 
 --- Validates the configuration passed to setup()
 ---@param opts table
 M.validate_config = function(opts)
-  vim.validate({
-    opts = { opts, "table" },
-  })
+  validate("opts", opts, "table")
 
   if opts.local_mark ~= nil then
-    vim.validate({
-      local_mark = { opts.local_mark, "table" },
-    })
+    validate("local_mark", opts.local_mark, "table")
     validate_mark_config(opts.local_mark, "local_mark")
   end
 
   if opts.global_mark ~= nil then
-    vim.validate({
-      global_mark = { opts.global_mark, "table" },
-    })
+    validate("global_mark", opts.global_mark, "table")
     validate_mark_config(opts.global_mark, "global_mark")
   end
 
   if opts.special_mark ~= nil then
-    vim.validate({
-      special_mark = { opts.special_mark, "table" },
-    })
+    validate("special_mark", opts.special_mark, "table")
     validate_mark_config(opts.special_mark, "special_mark")
   end
 
   if opts.autocmd_triggers ~= nil then
-    vim.validate({
-      autocmd_triggers = { opts.autocmd_triggers, "table" },
-    })
+    validate("autocmd_triggers", opts.autocmd_triggers, "table")
     if #opts.autocmd_triggers == 0 then
       error("autocmd_triggers cannot be empty (plugin won't refresh)")
     end
   end
 
   if opts.excluded_filetypes ~= nil then
-    vim.validate({
-      excluded_filetypes = { opts.excluded_filetypes, "table" },
-    })
+    validate("excluded_filetypes", opts.excluded_filetypes, "table")
   end
 
   if opts.excluded_buftypes ~= nil then
-    vim.validate({
-      excluded_buftypes = { opts.excluded_buftypes, "table" },
-    })
+    validate("excluded_buftypes", opts.excluded_buftypes, "table")
   end
 end
 


### PR DESCRIPTION
Hello,
:checkhealth raises warning due to the old form of vim.validate. See https://neovim.io/doc/user/lua/#vim.validate() for details.
I changed the form to the recommended one.
Seems to work fine.